### PR TITLE
Continues Work for HSV/RGB Op Templating

### DIFF
--- a/tensorflow/core/kernels/colorspace_op.cc
+++ b/tensorflow/core/kernels/colorspace_op.cc
@@ -114,6 +114,7 @@ class HSVToRGBOp : public OpKernel {
                           HSVToRGBOp<CPUDevice, T>);          \
   template class HSVToRGBOp<CPUDevice, T>;
 TF_CALL_float(REGISTER_CPU);
+TF_CALL_double(REGISTER_CPU);
 
 #if GOOGLE_CUDA
 // Forward declarations of the function specializations for GPU (to prevent
@@ -132,6 +133,7 @@ namespace functor {
       TTypes<T, 2>::Tensor output_data);                      \
   extern template struct HSVToRGB<GPUDevice, T>;
 TF_CALL_float(DECLARE_GPU);
+TF_CALL_double(DECLARE_GPU);
 }  // namespace functor
 #define REGISTER_GPU(T)                                       \
   REGISTER_KERNEL_BUILDER(Name("RGBToHSV").Device(DEVICE_GPU) \
@@ -141,6 +143,7 @@ TF_CALL_float(DECLARE_GPU);
                               .TypeConstraint<T>("T"),        \
                           HSVToRGBOp<GPUDevice, T>);
 TF_CALL_float(REGISTER_GPU);
+TF_CALL_double(REGISTER_GPU);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/colorspace_op.cc
+++ b/tensorflow/core/kernels/colorspace_op.cc
@@ -64,7 +64,7 @@ class RGBToHSVOp : public OpKernel {
 
     Tensor trange;
     OP_REQUIRES_OK(
-        context, context->allocate_temp(DataTypeToEnum<float>::value,
+        context, context->allocate_temp(DataTypeToEnum<T>::value,
                                         TensorShape({input_data.dimension(0)}),
                                         &trange));
 

--- a/tensorflow/core/kernels/colorspace_op_test.cc
+++ b/tensorflow/core/kernels/colorspace_op_test.cc
@@ -29,183 +29,244 @@ limitations under the License.
 
 namespace tensorflow {
 
+template <typename T>
 class RGBToHSVOpTest : public OpsTestBase {
  protected:
-  RGBToHSVOpTest() {
+  void MakeOp(DataType datatype) {
     TF_EXPECT_OK(NodeDefBuilder("rgb_to_hsv_op", "RGBToHSV")
-                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(datatype))
                      .Finalize(node_def()));
     TF_EXPECT_OK(InitOp());
   }
+
+  void CheckBlack(DataType datatype) {
+    // Black pixel should map to hsv = [0,0,0]
+    AddInputFromArray<T>(TensorShape({3}), {T(0), T(0), T(0)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(0.0), T(0.0), T(0.0)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));
+  }
+
+  void CheckGray(DataType datatype) {
+    // Gray pixel should have hue = saturation = 0.0, value = r/255
+    AddInputFromArray<T>(TensorShape({3}), {T(.5), T(.5), T(.5)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(0.0), T(0.0), T(.5)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));
+  }
+
+  void CheckWhite(DataType datatype) {
+    // Gray pixel should have hue = saturation = 0.0, value = 1.0
+    AddInputFromArray<T>(TensorShape({3}), {T(1), T(1), T(1)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(0.0), T(0.0), T(1.0)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));
+  }
+
+  void CheckRedMax(DataType datatype) {
+    // Test case where red channel dominates
+    AddInputFromArray<T>(TensorShape({3}), {T(.8), T(.4), T(.2)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    T expected_h = T(1.) / T(6.) * T(.2) / T(.6);
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.);
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {expected_h, expected_s, expected_v});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckGreenMax(DataType datatype) {
+    // Test case where green channel dominates
+    AddInputFromArray<T>(TensorShape({3}), {T(.2), T(.8), T(.4)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    T expected_h = T(1.) / T(6.) * (T(2.0) + (T(.2) / T(.6)));
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.);
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {expected_h, expected_s, expected_v});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckBlueMax(DataType datatype) {
+    // Test case where blue channel dominates
+    AddInputFromArray<T>(TensorShape({3}), {T(.4), T(.2), T(.8)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    T expected_h = T(1.) / T(6.) * (T(4.0) + (T(.2) / T(.6)));
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.);
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {expected_h, expected_s, expected_v});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckNegativeDifference(DataType datatype) {
+    AddInputFromArray<T>(TensorShape({3}), {T(0), T(.1), T(.2)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    T expected_h = T(1.) / T(6.) * (T(4.0) + (T(-.1) / T(.2)));
+    T expected_s = T(.2) / T(.2);
+    T expected_v = T(.2) / T(1.);
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {expected_h, expected_s, expected_v});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
 };
 
-TEST_F(RGBToHSVOpTest, CheckBlack) {
-  // Black pixel should map to hsv = [0,0,0]
-  AddInputFromArray<float>(TensorShape({3}), {0, 0, 0});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {0.0, 0.0, 0.0});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
-
-TEST_F(RGBToHSVOpTest, CheckGray) {
-  // Gray pixel should have hue = saturation = 0.0, value = r/255
-  AddInputFromArray<float>(TensorShape({3}), {.5, .5, .5});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {0.0, 0.0, .5});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
-
-TEST_F(RGBToHSVOpTest, CheckWhite) {
-  // Gray pixel should have hue = saturation = 0.0, value = 1.0
-  AddInputFromArray<float>(TensorShape({3}), {1, 1, 1});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {0.0, 0.0, 1.0});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
-
-TEST_F(RGBToHSVOpTest, CheckRedMax) {
-  // Test case where red channel dominates
-  AddInputFromArray<float>(TensorShape({3}), {.8, .4, .2});
-  TF_ASSERT_OK(RunOpKernel());
-
-  float expected_h = 1. / 6. * .2 / .6;
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.;
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {expected_h, expected_s, expected_v});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
-TEST_F(RGBToHSVOpTest, CheckGreenMax) {
-  // Test case where green channel dominates
-  AddInputFromArray<float>(TensorShape({3}), {.2, .8, .4});
-  TF_ASSERT_OK(RunOpKernel());
-
-  float expected_h = 1. / 6. * (2.0 + (.2 / .6));
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.;
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {expected_h, expected_s, expected_v});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
-TEST_F(RGBToHSVOpTest, CheckBlueMax) {
-  // Test case where blue channel dominates
-  AddInputFromArray<float>(TensorShape({3}), {.4, .2, .8});
-  TF_ASSERT_OK(RunOpKernel());
-
-  float expected_h = 1. / 6. * (4.0 + (.2 / .6));
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.;
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {expected_h, expected_s, expected_v});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
-TEST_F(RGBToHSVOpTest, CheckNegativeDifference) {
-  AddInputFromArray<float>(TensorShape({3}), {0, .1, .2});
-  TF_ASSERT_OK(RunOpKernel());
-
-  float expected_h = 1. / 6. * (4.0 + (-.1 / .2));
-  float expected_s = .2 / .2;
-  float expected_v = .2 / 1.;
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {expected_h, expected_s, expected_v});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
+template <typename T>
 class HSVToRGBOpTest : public OpsTestBase {
  protected:
-  HSVToRGBOpTest() {
+  void MakeOp(DataType datatype) {
     TF_EXPECT_OK(NodeDefBuilder("hsv_to_rgb_op", "HSVToRGB")
-                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(datatype))
                      .Finalize(node_def()));
     TF_EXPECT_OK(InitOp());
   }
+
+  void CheckBlack(DataType datatype) {
+    // Black pixel should map to rgb = [0,0,0]
+    AddInputFromArray<T>(TensorShape({3}), {T(0.0), T(0.0), T(0.0)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(0), T(0), T(0)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(T(0)));
+  }
+
+  void CheckGray(DataType datatype) {
+    // Gray pixel should have hue = saturation = 0.0, value = r/255
+    AddInputFromArray<T>(TensorShape({3}), {T(0.0), T(0.0), .5});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(.5), T(.5), T(.5)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));
+  }
+
+  void CheckWhite(DataType datatype) {
+    // Gray pixel should have hue = saturation = 0.0, value = 1.0
+    AddInputFromArray<T>(TensorShape({3}), {T(0.0), T(0.0), T(1.0)});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(1), T(1), T(1)});
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));
+  }
+
+  void CheckRedMax(DataType datatype) {
+    // Test case where red channel dominates
+    T expected_h = T(1.) / T(6.) * T(.2) / T(.6);
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.);
+
+    AddInputFromArray<T>(TensorShape({3}),
+                             {expected_h, expected_s, expected_v});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(.8), T(.4), T(.2)});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckGreenMax(DataType datatype) {
+    // Test case where green channel dominates
+    T expected_h = T(1.) / T(6.) * (T(2.0) + (T(.2) / T(.6)));
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.);
+
+    AddInputFromArray<T>(TensorShape({3}),
+                             {expected_h, expected_s, expected_v});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(.2), T(.8), T(.4)});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckBlueMax(DataType datatype) {
+    // Test case where blue channel dominates
+    T expected_h = T(1.) / T(6.) * (T(4.0) + (T(.2) / T(.6)));
+    T expected_s = T(.6) / T(.8);
+    T expected_v = T(.8) / T(1.0);
+
+    AddInputFromArray<T>(TensorShape({3}),
+                             {expected_h, expected_s, expected_v});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(.4), T(.2), T(.8)});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
+
+  void CheckNegativeDifference(DataType datatype) {
+    T expected_h = T(1.) / T(6.) * (T(4.0) + (T(-.1) / T(.2)));
+    T expected_s = T(.2) / T(.2);
+    T expected_v = T(.2) / T(1.);
+
+    AddInputFromArray<T>(TensorShape({3}),
+                             {expected_h, expected_s, expected_v});
+    TF_ASSERT_OK(RunOpKernel());
+
+    Tensor expected(allocator(), datatype, TensorShape({3}));
+    test::FillValues<T>(&expected, {T(0), T(.1), T(.2)});
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), 1e-6);
+  }
 };
 
-TEST_F(HSVToRGBOpTest, CheckBlack) {
-  // Black pixel should map to rgb = [0,0,0]
-  AddInputFromArray<float>(TensorShape({3}), {0.0, 0.0, 0.0});
-  TF_ASSERT_OK(RunOpKernel());
+#define TEST_COLORSPACE(clr, dt)                                \
+  TEST_F(clr, CheckBlack) {                                     \
+    MakeOp(dt);                                                 \
+    CheckBlack(dt);                                             \
+  }                                                             \
+  TEST_F(clr, CheckGray) {                                      \
+    MakeOp(dt);                                                 \
+    CheckGray(dt);                                              \
+  }                                                             \
+  TEST_F(clr, CheckWhite) {                                     \
+    MakeOp(dt);                                                 \
+    CheckWhite(dt);                                             \
+  }                                                             \
+  TEST_F(clr, CheckRedMax) {                                    \
+    MakeOp(dt);                                                 \
+    CheckRedMax(dt);                                            \
+  }                                                             \
+  TEST_F(clr, CheckGreenMax) {                                  \
+    MakeOp(dt);                                                 \
+    CheckGreenMax(dt);                                          \
+  }                                                             \
+  TEST_F(clr, CheckBlueMax) {                                   \
+    MakeOp(dt);                                                 \
+    CheckBlueMax(dt);                                           \
+  }                                                             \
+  TEST_F(clr, CheckNegativeDifference) {                        \
+    MakeOp(dt);                                                 \
+    CheckNegativeDifference(dt);                                \
+  }
 
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {0, 0, 0});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
+// Test RGBToHSVOp
+typedef RGBToHSVOpTest<float> RGBToHSVOpTest_float;
+typedef RGBToHSVOpTest<double> RGBToHSVOpTest_double;
 
-TEST_F(HSVToRGBOpTest, CheckGray) {
-  // Gray pixel should have hue = saturation = 0.0, value = r/255
-  AddInputFromArray<float>(TensorShape({3}), {0.0, 0.0, .5});
-  TF_ASSERT_OK(RunOpKernel());
+TEST_COLORSPACE(RGBToHSVOpTest_float, DT_FLOAT);
+TEST_COLORSPACE(RGBToHSVOpTest_double, DT_DOUBLE);
 
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {.5, .5, .5});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
+// Test HSVToRGBOp
+typedef HSVToRGBOpTest<float> HSVToRGBOpTest_float;
+typedef HSVToRGBOpTest<double> HSVToRGBOpTest_double;
 
-TEST_F(HSVToRGBOpTest, CheckWhite) {
-  // Gray pixel should have hue = saturation = 0.0, value = 1.0
-  AddInputFromArray<float>(TensorShape({3}), {0.0, 0.0, 1.0});
-  TF_ASSERT_OK(RunOpKernel());
+TEST_COLORSPACE(HSVToRGBOpTest_float, DT_FLOAT);
+TEST_COLORSPACE(HSVToRGBOpTest_double, DT_DOUBLE);
 
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {1, 1, 1});
-  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
-}
-
-TEST_F(HSVToRGBOpTest, CheckRedMax) {
-  // Test case where red channel dominates
-  float expected_h = 1. / 6. * .2 / .6;
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.;
-
-  AddInputFromArray<float>(TensorShape({3}),
-                           {expected_h, expected_s, expected_v});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {.8, .4, .2});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
-TEST_F(HSVToRGBOpTest, CheckGreenMax) {
-  // Test case where green channel dominates
-  float expected_h = 1. / 6. * (2.0 + (.2 / .6));
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.;
-
-  AddInputFromArray<float>(TensorShape({3}),
-                           {expected_h, expected_s, expected_v});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {.2, .8, .4});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
-
-TEST_F(HSVToRGBOpTest, CheckBlueMax) {
-  // Test case where blue channel dominates
-  float expected_h = 1. / 6. * (4.0 + (.2 / .6));
-  float expected_s = .6 / .8;
-  float expected_v = .8 / 1.0;
-
-  AddInputFromArray<float>(TensorShape({3}),
-                           {expected_h, expected_s, expected_v});
-  TF_ASSERT_OK(RunOpKernel());
-
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({3}));
-  test::FillValues<float>(&expected, {.4, .2, .8});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 1e-6);
-}
 }  // namespace tensorflow

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -353,7 +353,7 @@ contents: 0-D. PNG-encoded image.
 REGISTER_OP("RGBToHSV")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Doc(R"doc(
 Converts one or more images from RGB to HSV.
 
@@ -373,7 +373,7 @@ output: `images` converted to HSV.
 REGISTER_OP("HSVToRGB")
     .Input("images: T")
     .Output("output: T")
-    .Attr("T: {float}")
+    .Attr("T: {float, double} = DT_FLOAT")
     .Doc(R"doc(
 Convert one or more images from HSV to RGB.
 


### PR DESCRIPTION
This pull request does the following work on top of siddhart-agrawal/tensorflow/hsv_rgb_template:

* Registers both HSVToRGB and RGBToHSV for `float` and `double`, setting default value to `DT_FLOAT` for backwards compatibility
* Refactors tests to be reusable with different data types
* Adds HSVToRBG CheckNegativeDifference test, which was missing for some reason previously
* Cleans up a few missed `float` -> `T` bugs